### PR TITLE
mupdf (mutool) upgrade

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -65,7 +65,7 @@ class Engine extends EventEmitter2 {
     const p = os.platform()
     // Linux
     gsExecutable = GS_PATH || 'gs'
-    mupdfExecutable = MUPDF_PATH || 'mudraw'
+    mupdfExecutable = MUPDF_PATH || 'mutool'
     inkScapeExecutable = INKSCAPE_PATH || 'inkscape'
     imageMagickConvert = IM_PATH || 'convert'
     // Windows
@@ -260,10 +260,7 @@ class Engine extends EventEmitter2 {
     let tasks = pdfFiles.map((pdfPath, pdfIndex) => {
       return new Promise((resolve) => {
         const imgPrefix = `img-${pdfIndex}-`
-        let args = [`-r ${co.density}`, `-o ${imgPrefix}%d.png`, pdfPath]
-        if (isWindowsPlatform(os.platform())) {
-          args = ['draw', ...args]
-        }
+        let args = ['draw', `-r ${co.density}`, `-o ${imgPrefix}%d.png`, pdfPath]
         const muStart = nowInMillis()
         execFile(mupdfExecutable, args, {cwd: this._imgDir}, (err, stdout, stderr) => {
           this.emit('done.mupdf.convert', { output: `${mupdfExecutable} ${args.join(' ')}`, time: elapsed(muStart), error: err })

--- a/package-lock.json
+++ b/package-lock.json
@@ -366,7 +366,7 @@
         "babel-core": "6.26.0",
         "babel-generator": "6.26.1",
         "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "bluebird": "3.5.0",
+        "bluebird": "3.5.2",
         "caching-transform": "1.0.1",
         "chalk": "2.4.0",
         "chokidar": "1.7.0",
@@ -382,7 +382,7 @@
         "convert-source-map": "1.5.1",
         "core-assert": "0.2.1",
         "currently-unhandled": "0.4.1",
-        "debug": "3.1.0",
+        "debug": "3.2.6",
         "dot-prop": "4.2.0",
         "empower-core": "0.6.2",
         "equal-length": "1.0.1",
@@ -1006,9 +1006,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
+      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
     },
     "boxen": {
       "version": "1.3.0",
@@ -1538,11 +1538,18 @@
       "dev": true
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
       }
     },
     "debug-log": {
@@ -1773,7 +1780,7 @@
         "chalk": "2.4.0",
         "concat-stream": "1.6.2",
         "cross-spawn": "5.1.0",
-        "debug": "3.1.0",
+        "debug": "3.2.6",
         "doctrine": "2.1.0",
         "eslint-scope": "3.7.1",
         "eslint-visitor-keys": "1.0.0",
@@ -4015,7 +4022,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "multimatch": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-officegen",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Converts one or more PDFs into a powerpoint or word document with one pdf page per slide/page",
   "main": "index.js",
   "scripts": {
@@ -36,10 +36,10 @@
     "tap-diff": "^0.1.1"
   },
   "dependencies": {
-    "bluebird": "^3.4.6",
-    "debug": "^3.1.0",
+    "bluebird": "^3.5.2",
+    "debug": "^3.2.6",
     "eventemitter2": "^2.1.3",
-    "spider-officegen": "1.0.1",
-    "rimraf": "^2.6.2"
+    "rimraf": "^2.6.2",
+    "spider-officegen": "1.0.1"
   }
 }


### PR DESCRIPTION
mupdf v12 supports 'mutool draw' across all platforms, updating to fix runtime after updating downstream export server to latest ubuntu lts